### PR TITLE
Remove auto-updating of poetry lock file

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -23,6 +23,7 @@ jobs:
               with:
                 python-version: '3.10'
             - run: |
-                pip install poetry==1.3.1
+                curl -LsSf https://astral.sh/uv/install.sh | sh
+                uv pip install --system poetry==1.3.1
                 poetry install --all-extras --with dev
             - run: poetry run pytest tests/


### PR DESCRIPTION
This was a hack introduced in #2 and kept in to ensure #1 could be merged. I think we can safely remove it now. I'll also use uv to install poetry, as that should save a few seconds.